### PR TITLE
initial rich custom content blocks

### DIFF
--- a/app/controllers/admin/site_customization/content_blocks_controller.rb
+++ b/app/controllers/admin/site_customization/content_blocks_controller.rb
@@ -53,7 +53,8 @@ class Admin::SiteCustomization::ContentBlocksController < Admin::SiteCustomizati
       end
     elsif @content_block.update(content_block_params)
       notice = t("admin.site_customization.content_blocks.update.notice")
-      redirect_to admin_site_customization_content_blocks_path, notice: notice
+      return_to = params[:return_to]
+      redirect_to return_to ? return_to : admin_site_customization_content_blocks_path, notice: notice
     else
       flash.now[:error] = t("admin.site_customization.content_blocks.update.error")
       render :edit
@@ -103,6 +104,7 @@ class Admin::SiteCustomization::ContentBlocksController < Admin::SiteCustomizati
       if @content_block.save
         heading_content_block.destroy!
         notice = t("admin.site_customization.content_blocks.update.notice")
+
         redirect_to admin_site_customization_content_blocks_path, notice: notice
       else
         flash.now[:error] = t("admin.site_customization.content_blocks.update.error")

--- a/app/controllers/custom/content_blocks_helper.rb
+++ b/app/controllers/custom/content_blocks_helper.rb
@@ -1,0 +1,13 @@
+require_dependency Rails.root.join("app", "helpers", "content_blocks_helper").to_s
+module ContentBlocksHelper
+
+  def render_custom_block(key)
+    block = SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
+    if current_user.administrator?
+      edit_link = link_to t("admin.actions.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
+    end
+    res = block&.body || ""
+    res << edit_link ? "<br>#{edit_link}" : ""
+    raw res
+  end
+end

--- a/app/helpers/content_blocks_helper.rb
+++ b/app/helpers/content_blocks_helper.rb
@@ -8,4 +8,8 @@ module ContentBlocksHelper
     end
     options
   end
+
+  def render_custom_block(key)
+    raw SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
+  end
 end

--- a/app/helpers/content_blocks_helper.rb
+++ b/app/helpers/content_blocks_helper.rb
@@ -12,7 +12,7 @@ module ContentBlocksHelper
   def render_custom_block(key)
     block = SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
     if current_user.administrator?
-      edit_link = link_to t("admin.action.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
+      edit_link = link_to t("admin.actions.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
     end
     res = block&.body
     res << edit_link ? "<br>#{edit_link}" : ""

--- a/app/helpers/content_blocks_helper.rb
+++ b/app/helpers/content_blocks_helper.rb
@@ -14,7 +14,7 @@ module ContentBlocksHelper
     if current_user.administrator?
       edit_link = link_to t("admin.actions.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
     end
-    res = block&.body
+    res = block&.body || ""
     res << edit_link ? "<br>#{edit_link}" : ""
     raw res
   end

--- a/app/helpers/content_blocks_helper.rb
+++ b/app/helpers/content_blocks_helper.rb
@@ -8,14 +8,4 @@ module ContentBlocksHelper
     end
     options
   end
-
-  def render_custom_block(key)
-    block = SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
-    if current_user.administrator?
-      edit_link = link_to t("admin.actions.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
-    end
-    res = block&.body || ""
-    res << edit_link ? "<br>#{edit_link}" : ""
-    raw res
-  end
 end

--- a/app/helpers/content_blocks_helper.rb
+++ b/app/helpers/content_blocks_helper.rb
@@ -10,6 +10,12 @@ module ContentBlocksHelper
   end
 
   def render_custom_block(key)
-    raw SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
+    block = SiteCustomization::ContentBlock.custom_block_for(key, I18n.locale)
+    if current_user.administrator?
+      edit_link = link_to t("admin.action.edit"), edit_admin_site_customization_content_block_path(block, return_to: request.path )
+    end
+    res = block&.body
+    res << edit_link ? "<br>#{edit_link}" : ""
+    raw res
   end
 end

--- a/app/models/custom/site_customization/content_block.rb
+++ b/app/models/custom/site_customization/content_block.rb
@@ -1,0 +1,12 @@
+require_dependency Rails.root.join("app", "models", "site_customization", "content_block").to_s
+
+class SiteCustomization::ContentBlock < ApplicationRecord
+  def self.custom_block_for(key, locale)
+    locale ||= I18n.default_locale
+    find_or_create_by(name: 'custom', locale: locale, key: key)&.body
+  end
+
+  def custom?
+    name == 'custom'
+  end
+end

--- a/app/models/custom/site_customization/content_block.rb
+++ b/app/models/custom/site_customization/content_block.rb
@@ -3,7 +3,7 @@ require_dependency Rails.root.join("app", "models", "site_customization", "conte
 class SiteCustomization::ContentBlock < ApplicationRecord
   def self.custom_block_for(key, locale)
     locale ||= I18n.default_locale
-    find_or_create_by(name: 'custom', locale: locale, key: key)&.body
+    find_or_create_by(name: 'custom', locale: locale, key: key)
   end
 
   def custom?

--- a/app/models/site_customization/content_block.rb
+++ b/app/models/site_customization/content_block.rb
@@ -1,8 +1,8 @@
 class SiteCustomization::ContentBlock < ApplicationRecord
-  VALID_BLOCKS = %w[top_links footer subnavigation_left subnavigation_right].freeze
+  VALID_BLOCKS = %w[top_links footer subnavigation_left subnavigation_right custom].freeze
 
   validates :locale, presence: true, inclusion: { in: I18n.available_locales.map(&:to_s) }
-  validates :name, presence: true, uniqueness: { scope: :locale }, inclusion: { in: VALID_BLOCKS }
+  validates :name, presence: true, uniqueness: { scope: [:locale, :key] }, inclusion: { in: VALID_BLOCKS }
 
   def self.block_for(name, locale)
     locale ||= I18n.default_locale

--- a/app/views/custom/admin/site_customization/content_blocks/_form_content_block.html.erb
+++ b/app/views/custom/admin/site_customization/content_blocks/_form_content_block.html.erb
@@ -1,0 +1,27 @@
+<%= form_for [:admin, @content_block], html: { class: "edit_page" } do |f| %>
+
+  <%= render "shared/errors", resource: @content_block %>
+  <%if @content_block.custom?%>
+    <div class="small-12 medium-6 column">
+      <%=t("admin.site_customization.content_blocks.content_block.key") %>
+      <strong><%=@content_block.key%></strong>
+    </div>
+    <%=f.hidden_field :name%>
+    <%=f.hidden_field :locale%>
+  <%else%>
+    <div class="small-12 medium-6 column">
+      <%= f.select :name, options_for_select(valid_blocks, @selected_content_block) %>
+    </div>
+    <div class="small-12 medium-6 column">
+      <%= f.select :locale, I18n.available_locales %>
+    </div>
+  <%end%>
+
+  <div class="small-12 column">
+    <%= f.text_area :body, rows: 10, class: @content_block.custom? ? "html-area admin" : "" %>
+    <div class="small-12 medium-6 large-3">
+      <%= f.submit class: "button success expanded" %>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/custom/admin/site_customization/content_blocks/_form_content_block.html.erb
+++ b/app/views/custom/admin/site_customization/content_blocks/_form_content_block.html.erb
@@ -7,6 +7,7 @@
       <strong><%=@content_block.key%></strong>
     </div>
     <%=f.hidden_field :name%>
+    <%=hidden_field_tag :return_to, params[:return_to]%>
     <%=f.hidden_field :locale%>
   <%else%>
     <div class="small-12 medium-6 column">

--- a/app/views/custom/admin/site_customization/content_blocks/edit.html.erb
+++ b/app/views/custom/admin/site_customization/content_blocks/edit.html.erb
@@ -1,0 +1,16 @@
+<% provide :title do %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.content_blocks") %> - <%= @content_block.try(:name) || @content_block.heading.try(:name) %> (<%= @content_block.locale %>)
+<% end %>
+
+<%= back_link_to admin_site_customization_content_blocks_path %>
+
+<%= link_to t("admin.site_customization.content_blocks.index.delete"),
+            (@is_heading_content_block ? admin_site_customization_delete_heading_content_block_path(@content_block.id) : admin_site_customization_content_block_path(@content_block)),
+            method: :delete,
+            class: "delete float-right" %>
+
+<div class="small-12 column">
+  <h2><%= t("admin.site_customization.content_blocks.edit.title") %></h2>
+</div>
+
+<%= render "form" %>

--- a/app/views/custom/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/custom/admin/site_customization/content_blocks/index.html.erb
@@ -1,0 +1,62 @@
+<% provide :title do %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.content_blocks") %>
+<% end %>
+
+<%= link_to t("admin.site_customization.content_blocks.index.create"), new_admin_site_customization_content_block_path, class: "button float-right" %>
+
+<h2 class="inline-block"><%= t("admin.site_customization.content_blocks.index.title") %></h2>
+
+<%= render "admin/settings/settings_table", settings: @html_settings, setting_name: "setting" %>
+
+<h3><%= t("admin.site_customization.content_blocks.information") %></h3>
+
+<p><%= t("admin.site_customization.content_blocks.about") %></p>
+<p><%= t("admin.site_customization.content_blocks.html_format") %></p>
+
+<p>
+  <code><%= '<li><a href="http://site1.com">Site 1</a></li>' %></code><br>
+  <code><%= '<li><a href="http://site2.com">Site 2</a></li>' %></code><br>
+  <code><%= '<li><a href="http://site3.com">Site 3</a></li>' %></code><br>
+</p>
+
+<% if @content_blocks.any? || @headings_content_blocks.any? %>
+  <table class="cms-page-list">
+    <thead>
+      <tr>
+        <th><%= t("admin.site_customization.content_blocks.content_block.name") %></th>
+        <th><%= t("admin.site_customization.content_blocks.content_block.key") %></th>
+        <th><%= t("admin.site_customization.content_blocks.content_block.body") %></th>
+        <th><%= t("admin.actions.actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @content_blocks.each do |content_block| %>
+      <tr id="<%= dom_id(content_block) %>">
+        <td><%= link_to "#{content_block.name} (#{content_block.locale})", edit_admin_site_customization_content_block_path(content_block) %></td>
+        <td><%= link_to content_block.key || "", edit_admin_site_customization_content_block_path(content_block) %></td>
+        <td><%=content_block.custom? ? '' : raw(content_block.body) %></td>
+        <td>
+          <%= link_to t("admin.site_customization.content_blocks.index.delete"),
+                        admin_site_customization_content_block_path(content_block),
+                        method: :delete, class: "button hollow alert" %>
+        </td>
+      </tr>
+    <% end %>
+    <% @headings_content_blocks.each do |content_block| %>
+      <tr id="<%= dom_id(content_block) %>">
+        <td><%= link_to "#{content_block.heading.name} (#{content_block.locale})", admin_site_customization_edit_heading_content_block_path(content_block) %></td>
+        <td><%= raw content_block.body %></td>
+        <td>
+          <%= link_to t("admin.site_customization.content_blocks.index.delete"),
+                        admin_site_customization_delete_heading_content_block_path(content_block.id),
+                        method: :delete, class: "button hollow alert" %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.site_customization.content_blocks.no_blocks") %>
+  </div>
+<% end %>

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -75,6 +75,8 @@
         <% if has_banners? %>
           <%= render "shared/banner" %>
         <% end %>
+        <%=render_custom_block 'proposals_welcome' %>
+
         <% if show_featured_proposals? %>
           <div id="featured-proposals" class="row featured-proposals">
             <div class="small-12 column">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1489,6 +1489,7 @@ en:
         content_block:
           body: Body
           name: Name
+          key: Key
           names:
             top_links: Top Links
             footer: Footer

--- a/db/migrate/20210218195121_add_key_to_content_block.rb
+++ b/db/migrate/20210218195121_add_key_to_content_block.rb
@@ -1,0 +1,7 @@
+class AddKeyToContentBlock < ActiveRecord::Migration[5.1]
+  def change
+    add_column :site_customization_content_blocks, :key, :string
+    remove_index :site_customization_content_blocks, name: :index_site_customization_content_blocks_on_name_and_locale
+    add_index :site_customization_content_blocks, [:key, :name, :locale], unique: true, name: :locale_key_name_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210203202811) do
+ActiveRecord::Schema.define(version: 20210218195121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1331,7 +1331,8 @@ ActiveRecord::Schema.define(version: 20210203202811) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name", "locale"], name: "index_site_customization_content_blocks_on_name_and_locale", unique: true
+    t.string "key"
+    t.index ["key", "name", "locale"], name: "locale_key_name_index", unique: true
   end
 
   create_table "site_customization_images", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Allows inserting editable rich content in any part of the page.

Example: 
`<%=render_custom_block 'proposals_welcome' %>`

Then this content can be editable in admin section at **Settings** ⇾ **Custom Content Blocks**
